### PR TITLE
Remove broken link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Page analyzer
 
-This Apify actor analyzes a web page on a specific URL. You can try out how it works live in the [Page Analyzer](https://apify.com/page-analyzer) on Apify.
-This actor extracts HTML and javascript variables from main response and HTML/JSON data from XHR requests.
+This Apify actor analyzes a web page on a specific URL.
+It extracts HTML and javascript variables from main response and HTML/JSON data from XHR requests.
 Then it analyses loaded data:
 1) It performs analysis of initial HTML (html loaded directly from response):
 - Looks for Schema.org data and if it finds anything, it saves it to output as ``schemaOrgData`` variable.


### PR DESCRIPTION
We removed the Page Analyzer page from the web because it was broken and it requires a bigger rewrite, so I removed the now broken link from this actor's README.